### PR TITLE
Allow separate ssl certs for web and websocket domains

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,8 @@ OPENCRAFT_OPENSTACK_SSH_KEY: null
 # Contents of console ssl certificate
 OPENCRAFT_SSL_CERT: null
 OPENCRAFT_SSL_KEY: null
+OPENCRAFT_WEBSOCKET_SSL_CERT: null
+OPENCRAFT_WEBSOCKET_SSL_KEY: null
 
 # Settings for the OpenCraft Instance manager.  See opencraft/settings.py for details.
 OPENCRAFT_ENV_TOKENS:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,8 +49,14 @@
 - name: Copy SSL certificate
   copy: content="{{ OPENCRAFT_SSL_CERT }}" dest=/etc/ssl/certs/ssl-cert.pem group=ssl-cert mode=640
 
-- name: Copy SSL certificate
+- name: Copy SSL key
   copy: content="{{ OPENCRAFT_SSL_KEY }}" dest=/etc/ssl/private/ssl-cert.key group=ssl-cert mode=640
+
+- name: Copy websocket SSL certificate
+  copy: content="{{ OPENCRAFT_WEBSOCKET_SSL_CERT }}" dest=/etc/ssl/certs/ssl-websocket-cert.pem group=ssl-cert mode=640
+
+- name: Copy websocket SSL key
+  copy: content="{{ OPENCRAFT_WEBSOCKET_SSL_KEY }}" dest=/etc/ssl/private/ssl-websocket-cert.key group=ssl-cert mode=640
 
 - name: Restart nginx
   service: name=nginx state=restarted

--- a/templates/opencraft-nginx.j2
+++ b/templates/opencraft-nginx.j2
@@ -74,8 +74,8 @@ server {
     server_name {{ OPENCRAFT_WEBSOCKET_DOMAIN_NAME }};
 
     ssl on;
-    ssl_certificate /etc/ssl/certs/ssl-cert.pem;
-    ssl_certificate_key /etc/ssl/private/ssl-cert.key;
+    ssl_certificate /etc/ssl/certs/ssl-websocket-cert.pem;
+    ssl_certificate_key /etc/ssl/private/ssl-websocket-cert.key;
 
     add_header Strict-Transport-Security "max-age=31536000";
 


### PR DESCRIPTION
I bought separate SSL certs for OpenCraft IM stage.

This was already proposed as a change to https://github.com/open-craft/ansible-opencraft/pull/3 in https://github.com/open-craft/ansible-opencraft/pull/4, but https://github.com/open-craft/ansible-opencraft/pull/3 was merged first so the change never landed in master.
