### PR TITLE
Add systemd service to automatically start Ocim.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,10 @@ OPENCRAFT_SSL_KEY: null
 OPENCRAFT_WEBSOCKET_SSL_CERT: null
 OPENCRAFT_WEBSOCKET_SSL_KEY: null
 
+# Number of workers to run
+OPENCRAFT_WORKERS: 3
+OPENCRAFT_WORKERS_LOW_PRIORITY: 3
+
 OPENCRAFT_BACKUP_SWIFT_ENABLED: false
 OPENCRAFT_BACKUP_SWIFT_TARGET: /var/cache/swift-data-backup
 OPENCRAFT_BACKUP_SWIFT_TARSNAP_KEY_LOCATION: /etc/tarsnap.key
@@ -68,3 +72,4 @@ www_data_home_dir: '/var/www'
 opencraft_root_dir: '/var/www/opencraft'
 opencraft_virtualenv_dir: '/var/www/.virtualenvs/opencraft'
 opencraft_static_files_dir: '{{ opencraft_root_dir }}/build/static'
+opencraft_screenrc_path: '/home/ubuntu/ocim-screenrc'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,13 @@
 - name: Create {{ www_data_home_dir }}
   file: path="{{ www_data_home_dir }}" owner=www-data group=www-data mode=750 state=directory
 
+- name: Copy shell configuration for user www-data
+  template:
+    src: "bashrc"
+    dest: "{{ www_data_home_dir }}/.bashrc"
+    owner: www-data
+    group: www-data
+
 - name: Clone the opencraft repository
   git: repo=https://github.com/open-craft/opencraft.git dest="{{ opencraft_root_dir }}" update=no
   become_user: www-data
@@ -63,6 +70,25 @@
 
 - name: Restart nginx
   service: name=nginx state=restarted
+
+- name: Copy screen session configuration
+  template:
+    src: "ocim-screenrc"
+    dest: "{{ opencraft_screenrc_path }}"
+    owner: ubuntu
+    group: ubuntu
+
+- name: Copy systemd service file
+  template:
+    src: "ocim-screen.service"
+    dest: "/etc/systemd/system/ocim-screen.service"
+
+- name: enable and start the systemd service
+  # The systemd module is only available in Ansible 2.2 or later, so we need to
+  # use command here.
+  command: "systemctl {{ item }} ocim-screen.service"
+  with_items:
+    - ["enable", "start"]
 
 - name: Open HTTP port on the firewall
   ufw: rule=allow port={{ item }} proto=tcp

--- a/templates/bashrc
+++ b/templates/bashrc
@@ -1,0 +1,11 @@
+. {{ opencraft_virtualenv_dir }}/bin/activate
+
+export WORKERS={{ OPENCRAFT_WORKERS }}
+export WORKERS_LOW_PRIORITY={{ OPENCRAFT_WORKERS_LOW_PRIORITY }}
+
+# Prevent accidential closing of shells inside screen or tmux
+case $TERM in
+    screen*)
+        IGNOREEOF=10
+        ;;
+esac

--- a/templates/ocim-screen.service
+++ b/templates/ocim-screen.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Screen session running the Ocim web server
+Documentation=https://github.com/open-craft/opencraft/tree/master/deploy/README.md
+After=nginx.service
+
+[Service]
+ExecStart=/usr/bin/screen -D -m -c {{ opencraft_screenrc_path }}
+Restart=no
+User=ubuntu
+Group=ubuntu
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/ocim-screenrc
+++ b/templates/ocim-screenrc
@@ -1,0 +1,13 @@
+screen
+stuff "sudo -s -H -u www-data\n"
+stuff "cd {{ opencraft_root_dir }}\n"
+stuff "make run\n"
+
+screen
+stuff "sudo -s -H -u www-data\n"
+stuff "cd {{ opencraft_root_dir }}\n"
+stuff "make shell\n"
+
+screen
+stuff "sudo -s -H -u www-data\n"
+stuff "cd {{ opencraft_root_dir }}\n"


### PR DESCRIPTION
WIP – not ready for review yet.

This change adds a systemd service to automatically start the instance manager at system boot.

So far, we managed the instance manager manually from a screen session.  This allows easy deployment of new versions, and is currently good enough, so the approach we take here is to automatically launch the screen session we used to start manually.  This proved a bit more tricky than anticipated.

The first problem is that we want to run bash inside the multiple screen windows, but we want to start a few commands within the bash at startup.  However, bash does not have a command-line option to run a few commands and than enter interactive mode.  This problem was solved by using screen's config file to stuff the commands we want to run into screen's input buffer, so the shell thinks they have been typed in manually.

The second problem is that we can't run the screen session as user `www-data`.  If we would do that, a user logging in as `ubuntu` and sudoing to `www-data` would not have permission to attach to the screen session due to pty permission issues.  So we run the session as user `ubuntu` and sudo to `www-data` inside each window.

The PR also adds a `.bashrc` file for `www-data` to automatically activate the virtualenv for interactive shells.

For testing, I've successfully deployed this to the stage server.