### PR TITLE
Add support for setting up developer environment on Vagrant

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,3 +73,11 @@ opencraft_root_dir: '/var/www/opencraft'
 opencraft_virtualenv_dir: '/var/www/.virtualenvs/opencraft'
 opencraft_static_files_dir: '{{ opencraft_root_dir }}/build/static'
 opencraft_screenrc_path: '/home/ubuntu/ocim-screenrc'
+
+# The user you will log in as in an SSH session and their primary group
+session_user: ubuntu
+session_user_group: ubuntu
+
+# The user and group under which the applicaiton code will run
+www_user: www-data
+www_group: www-data

--- a/tasks/configure-swift-backups.yml
+++ b/tasks/configure-swift-backups.yml
@@ -2,13 +2,13 @@
   template:
     src: "tarsnap.key.j2"
     dest: "{{ OPENCRAFT_BACKUP_SWIFT_TARSNAP_KEY_LOCATION }}"
-    owner: "www-data"
+    owner: "{{ www_user }}"
     group: "root"
 
 - name: create backup folders
   file:
     name: "{{ item }}"
-    owner: "www-data"
+    owner: "{{ www_user }}"
     group: "root"
     state: "directory"
   with_items:
@@ -28,7 +28,7 @@
 - name: chmod volume
   file:
     path: "{{ OPENCRAFT_BACKUP_SWIFT_TARGET }}"
-    owner: "www-data"
+    owner: "{{ www_user }}"
     group: "root"
     state: "folder"
     recurse: "yes"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,27 +1,29 @@
 - include: configure-swift-backups.yml
   when: "{{ OPENCRAFT_BACKUP_SWIFT_ENABLED }}"
 
-- name: Set login shell for user www-data
-  user: name=www-data shell=/bin/bash
+- name: Set login shell for user {{ www_user }}
+  user: name={{ www_user }} shell=/bin/bash
 
 - name: Create {{ www_data_home_dir }}
   file:
     path: "{{ www_data_home_dir }}"
-    owner: www-data
-    group: www-data
+    owner: "{{ www_user }}"
+    group: "{{ www_group }}"
     mode: 0750
     state: directory
 
-- name: Copy shell configuration for user www-data
+- name: Copy shell configuration for user {{ www_user }}
+  when: vagrant_mode is undefined or not vagrant_mode
   template:
     src: "bashrc"
     dest: "{{ www_data_home_dir }}/.bashrc"
-    owner: www-data
-    group: www-data
+    owner: '{{ www_user }}'
+    group: '{{ www_group }}'
 
 - name: Clone the opencraft repository
+  when: vagrant_mode is undefined or not vagrant_mode
   git: repo=https://github.com/open-craft/opencraft.git dest="{{ opencraft_root_dir }}" update=no
-  become_user: www-data
+  become_user: "{{ www_user }}"
 
 - name: Install system dependencies
   command: make install_system_dependencies chdir="{{ opencraft_root_dir }}"
@@ -34,94 +36,105 @@
     requirements="{{ opencraft_root_dir }}/requirements.txt"
     virtualenv="{{ opencraft_virtualenv_dir }}"
     virtualenv_python=python3.5
-  become_user: www-data
+  become_user: "{{ www_user }}"
 
 - name: Install the venv wrapper script
   copy:
     src: venv_exec
     dest: "{{ opencraft_virtualenv_dir }}/bin/exec"
     mode: 0755
-  become_user: www-data
+  become_user: "{{ www_user }}"
 
 - name: Install the configuration/environment file
   template:
     src: env.j2
     dest: "{{ opencraft_root_dir }}/.env"
     mode: 0600
-  become_user: www-data
+  become_user: "{{ www_user }}"
 
 - name: "Create directory {{ www_data_home_dir }}/.ssh"
+  when: vagrant_mode is undefined or not vagrant_mode
   file: path="{{ www_data_home_dir }}/.ssh" state=directory
-  become_user: www-data
+  become_user: "{{ www_user }}"
 
 - name: Install the SSH private key used for deploying instances.
+  when: vagrant_mode is undefined or not vagrant_mode
   copy:
     content: "{{ OPENCRAFT_OPENSTACK_SSH_KEY }}"
     dest: "{{ www_data_home_dir }}/.ssh/id_rsa"
     mode: 0600
-  become_user: www-data
+  become_user: "{{ www_user }}"
 
-- name: Copy nginx site configuration
-  template: src=opencraft-nginx.j2 dest=/etc/nginx/sites-available/opencraft
+- name: Nginx setup
+  when: vagrant_mode is undefined or not vagrant_mode
+  block:
+  - name: Copy nginx site configuration
+    template: src=opencraft-nginx.j2 dest=/etc/nginx/sites-available/opencraft  
 
-- name: Enable nginx site configuration
-  file: src=/etc/nginx/sites-available/opencraft dest=/etc/nginx/sites-enabled/opencraft state=link
+  - name: Enable nginx site configuration
+    file: src=/etc/nginx/sites-available/opencraft dest=/etc/nginx/sites-enabled/opencraft state=link
 
-- name: Copy SSL certificate
-  copy:
-    content: "{{ OPENCRAFT_SSL_CERT }}"
-    dest: /etc/ssl/certs/ssl-cert.pem
-    group: ssl-cert
-    mode: 0640
+- name: SSL Setup
+  when: vagrant_mode is undefined or not vagrant_mode
+  block:
+    - name: Copy SSL certificate
+      copy:
+        content: "{{ OPENCRAFT_SSL_CERT }}"
+        dest: /etc/ssl/certs/ssl-cert.pem
+        group: ssl-cert
+        mode: 0640    
 
-- name: Copy SSL key
-  copy:
-    content: "{{ OPENCRAFT_SSL_KEY }}"
-    dest: /etc/ssl/private/ssl-cert.key
-    group: ssl-cert
-    mode: 0640
+    - name: Copy SSL key
+      copy:
+        content: "{{ OPENCRAFT_SSL_KEY }}"
+        dest: /etc/ssl/private/ssl-cert.key
+        group: ssl-cert
+        mode: 0640
 
-- name: Copy websocket SSL certificate
-  copy:
-    content: "{{ OPENCRAFT_WEBSOCKET_SSL_CERT }}"
-    dest: /etc/ssl/certs/ssl-websocket-cert.pem
-    group: ssl-cert
-    mode: 0640
+    - name: Copy websocket SSL certificate
+      copy:
+        content: "{{ OPENCRAFT_WEBSOCKET_SSL_CERT }}"
+        dest: /etc/ssl/certs/ssl-websocket-cert.pem
+        group: ssl-cert
+        mode: 0640
 
-- name: Copy websocket SSL key
-  copy:
-    content: "{{ OPENCRAFT_WEBSOCKET_SSL_KEY }}"
-    dest: /etc/ssl/private/ssl-websocket-cert.key
-    group: ssl-cert
-    mode: 0640
+    - name: Copy websocket SSL key
+      copy:
+        content: "{{ OPENCRAFT_WEBSOCKET_SSL_KEY }}"
+        dest: /etc/ssl/private/ssl-websocket-cert.key
+        group: ssl-cert
+        mode: 0640
 
 - name: Restart nginx
+  when: vagrant_mode is undefined or not vagrant_mode
   service: name=nginx state=restarted
 
-- name: Copy screen session configuration
-  template:
-    src: "ocim-screenrc"
-    dest: "{{ opencraft_screenrc_path }}"
-    owner: ubuntu
-    group: ubuntu
+- name: Screen configuration
+  when: vagrant_mode is undefined or not vagrant_mode
+  block:
+    - name: Copy screen session configuration
+      template:
+        src: "ocim-screenrc"
+        dest: "{{ opencraft_screenrc_path }}"
+        owner: "{{ session_user }}"
+        group: "{{ session_user_group }}"
 
-- name: Copy systemd service file
-  template:
-    src: "ocim-screen.service"
-    dest: "/etc/systemd/system/ocim-screen.service"
+    - name: Copy systemd service file
+      template:
+        src: "ocim-screen.service"
+        dest: "/etc/systemd/system/ocim-screen.service"
 
-- name: Enable the systemd service to start on boot automatically
-  systemd:
-    name: ocim-screen.service
-    enabled: yes
-
-- name: Start the systemd service right now
-  systemd:
-    name: ocim-screen.service
-    state: started
+    - name: Enable and start systemd service to start on boot automatically
+      systemd:
+        name: ocim-screen.service
+        enabled: yes
+        state: started
 
 - name: Open HTTP port on the firewall
   ufw: rule=allow port={{ item }} proto=tcp
   with_items:
     - 80
     - 443
+
+- include: vagrant_specific.yml
+  when: vagrant_mode is not undefined and vagrant_mode

--- a/tasks/vagrant_specific.yml
+++ b/tasks/vagrant_specific.yml
@@ -1,0 +1,45 @@
+---
+- name: Install database dependencies
+  shell: DEBIAN_FRONTEND=noninteractive make install_system_db_dependencies chdir="{{ opencraft_root_dir }}"
+
+- name: Open HTTP ports needed for dev setup
+  ufw: rule=allow port={{ item }} proto=tcp
+  with_items:
+    - 2001
+    - 5000
+    - 8888
+
+- name: Change directory to ~/opencraft on login
+  blockinfile:
+    path: ~/.bashrc
+    block:
+      . {{ opencraft_virtualenv_dir }}/bin/activate
+      cd ~/opencraft
+  become_user: vagrant
+
+- name: Setup Databases
+  block:
+    - shell: >
+        echo "update user set plugin='mysql_native_password' where user='root' and host='localhost'; flush privileges;" | \
+        sudo -H -u root mysql mysql
+
+    - name: Create Postgres user
+      shell: createuser -d vagrant
+      become_user: postgres
+      ignore_errors: yes
+
+    - name: Allow access to postgres from localhost without password
+      copy:
+        dest: /etc/postgresql/9.5/main/pg_hba.conf
+        content: |
+          local   all             postgres                                peer
+          local   all             all                                     trust
+          host    all             all             127.0.0.1/32            trust
+          host    all             all             ::1/128                 trust
+
+    - name: Restart postgres
+      service: name=postgresql state=restarted
+
+    - name: Create postgres database
+      command: make create_db chdir={{ opencraft_root_dir }}
+      become_user: vagrant

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -1,3 +1,3 @@
-{% for var, value in opencraft_all_env_tokens.iteritems()|sort %}
+{% for var, value in opencraft_all_env_tokens.items()|sort %}
 {{ var }}='{{ value }}'
 {% endfor %}

--- a/templates/ocim-screen.service
+++ b/templates/ocim-screen.service
@@ -6,8 +6,8 @@ After=nginx.service
 [Service]
 ExecStart=/usr/bin/screen -D -m -c {{ opencraft_screenrc_path }}
 Restart=no
-User=ubuntu
-Group=ubuntu
+User={{ session_user }}
+Group={{ session_user_group }}
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/ocim-screenrc
+++ b/templates/ocim-screenrc
@@ -1,13 +1,13 @@
 screen
-stuff "sudo -s -H -u www-data\n"
+stuff "sudo -s -H -u {{ www_user }}\n"
 stuff "cd {{ opencraft_root_dir }}\n"
 stuff "make run\n"
 
 screen
-stuff "sudo -s -H -u www-data\n"
+stuff "sudo -s -H -u {{ www_user }}\n"
 stuff "cd {{ opencraft_root_dir }}\n"
 stuff "make shell\n"
 
 screen
-stuff "sudo -s -H -u www-data\n"
+stuff "sudo -s -H -u {{ www_user }}\n"
 stuff "cd {{ opencraft_root_dir }}\n"


### PR DESCRIPTION
Adds support for setting up a developer environment when running in Vagrant, so a separate bootstrap script is not needed. 

**Dependencies**: 
Work with open-craft/opencraft#260

**Merge deadline**: None

**Testing instructions**:
See open-craft/opencraft#260

**Reviewers**
- [ ] TBD